### PR TITLE
all: early returns and fewer line breaks in func main

### DIFF
--- a/01-startup/main.go
+++ b/01-startup/main.go
@@ -8,17 +8,12 @@ import (
 )
 
 func main() {
-	logger := log.New(os.Stdout,
-		"INFO: ",
-		log.Ldate|log.Ltime|log.Lshortfile)
-	err := runServer(logger)
-	if err == nil {
-		logger.Println("finished clean")
-		os.Exit(0)
-	} else {
+	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
+	if err := runServer(logger); err != nil {
 		logger.Printf("Got error: %v", err)
 		os.Exit(1)
 	}
+	logger.Println("Finished clean")
 }
 
 func runServer(logger *log.Logger) error {

--- a/02-shutdown/main.go
+++ b/02-shutdown/main.go
@@ -12,17 +12,12 @@ import (
 )
 
 func main() {
-	logger := log.New(os.Stdout,
-		"INFO: ",
-		log.Ldate|log.Ltime|log.Lshortfile)
-	err := runServer(logger)
-	if err == nil {
-		logger.Println("finished clean")
-		os.Exit(0)
-	} else {
+	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
+	if err := runServer(logger); err != nil {
 		logger.Printf("Got error: %v", err)
 		os.Exit(1)
 	}
+	logger.Println("Finished clean")
 }
 
 func runServer(logger *log.Logger) error {

--- a/03-json/main.go
+++ b/03-json/main.go
@@ -12,17 +12,12 @@ import (
 )
 
 func main() {
-	logger := log.New(os.Stdout,
-		"INFO: ",
-		log.Ldate|log.Ltime|log.Lshortfile)
-	err := runServer(logger)
-	if err == nil {
-		logger.Println("finished clean")
-		os.Exit(0)
-	} else {
+	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
+	if err := runServer(logger); err != nil {
 		logger.Printf("Got error: %v", err)
 		os.Exit(1)
 	}
+	logger.Println("Finished clean")
 }
 
 func runServer(logger *log.Logger) error {


### PR DESCRIPTION
I removed the line breaks from the `log.New` call following the "in the middle of function calls" part of https://github.com/golang/go/wiki/CodeReviewComments#line-length.

I relied on an early return in the error case, rather than `os.Exit(0)` following https://github.com/golang/go/wiki/CodeReviewComments#indent-error-flow.