### PR TITLE
Remove assert helpers, use rr.Body.String(), simplify table test args

### DIFF
--- a/01-startup/main_test.go
+++ b/01-startup/main_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,74 +8,42 @@ import (
 )
 
 func TestEcho(t *testing.T) {
-	httpTestWriter := httptest.NewRecorder()
-	type args struct {
-		w http.ResponseWriter
-		r *http.Request
-	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name   string
+		method string
+		path   string
+		want   string
 	}{
 		{
-			name: "No specific path",
-			args: args{
-				w: httpTestWriter,
-				r: &http.Request{
-					Method: "GET",
-					URL: &url.URL{
-						Path: "/",
-					},
-				},
-			},
-			want: "You asked to GET /\n",
+			name:   "No specific path",
+			method: "GET",
+			path:   "/",
+			want:   "You asked to GET /\n",
 		},
 		{
-			name: "Posting to /foo/bar",
-			args: args{
-				w: httpTestWriter,
-				r: &http.Request{
-					Method: "POST",
-					URL: &url.URL{
-						Path: "/foo/bar",
-					},
-				},
-			},
-			want: "You asked to POST /foo/bar\n",
+			name:   "Posting to /foo/bar",
+			method: "POST",
+			path:   "/foo/bar",
+			want:   "You asked to POST /foo/bar\n",
 		},
 	}
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			Echo(tt.args.w, tt.args.r)
-			actual, _ := ioutil.ReadAll(httpTestWriter.Body)
-			assertStatus(t, httpTestWriter.Code, http.StatusOK)
-			assertResponseBody(t, string(actual), tt.want)
+			r := &http.Request{
+				Method: tt.method,
+				URL: &url.URL{
+					Path: tt.path,
+				},
+			}
+			rr := httptest.NewRecorder()
+			Echo(rr, r)
+			if rr.Code != http.StatusOK {
+				t.Errorf("Echo did not get correct status, got %d, want %d", rr.Code, http.StatusOK)
+			}
+			if got := rr.Body.String(); got != tt.want {
+				t.Errorf("Echo response body is wrong, got %q want %q", got, tt.want)
+			}
 		})
-	}
-}
-
-func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
-	if a == b {
-		return
-	}
-	if message == "" {
-		message = fmt.Sprintf("%v != %v", a, b)
-	}
-	t.Fatal(message)
-}
-
-func assertStatus(t *testing.T, got, want int) {
-	t.Helper()
-	if got != want {
-		t.Errorf("did not get correct status, got %d, want %d", got, want)
-	}
-}
-
-func assertResponseBody(t *testing.T, got, want string) {
-	t.Helper()
-	if got != want {
-		t.Errorf("response body is wrong, got %q want %q", got, want)
 	}
 }

--- a/02-shutdown/main_test.go
+++ b/02-shutdown/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -15,50 +14,42 @@ import (
 )
 
 func TestEcho(t *testing.T) {
-	httpTestWriter := httptest.NewRecorder()
-	type args struct {
-		w http.ResponseWriter
-		r *http.Request
-	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name   string
+		method string
+		path   string
+		want   string
 	}{
 		{
-			name: "No specific path",
-			args: args{
-				w: httpTestWriter,
-				r: &http.Request{
-					Method: "GET",
-					URL: &url.URL{
-						Path: "/",
-					},
-				},
-			},
-			want: "You asked to GET /\n",
+			name:   "No specific path",
+			method: "GET",
+			path:   "/",
+			want:   "You asked to GET /\n",
 		},
 		{
-			name: "Posting to /foo/bar",
-			args: args{
-				w: httpTestWriter,
-				r: &http.Request{
-					Method: "POST",
-					URL: &url.URL{
-						Path: "/foo/bar",
-					},
-				},
-			},
-			want: "You asked to POST /foo/bar\n",
+			name:   "Posting to /foo/bar",
+			method: "POST",
+			path:   "/foo/bar",
+			want:   "You asked to POST /foo/bar\n",
 		},
 	}
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			Echo(tt.args.w, tt.args.r)
-			actual, _ := ioutil.ReadAll(httpTestWriter.Body)
-			assertStatus(t, httpTestWriter.Code, http.StatusOK)
-			assertResponseBody(t, tt.want, string(actual))
+			r := &http.Request{
+				Method: tt.method,
+				URL: &url.URL{
+					Path: tt.path,
+				},
+			}
+			rr := httptest.NewRecorder()
+			Echo(rr, r)
+			if rr.Code != http.StatusOK {
+				t.Errorf("Echo did not get correct status, got %d, want %d", rr.Code, http.StatusOK)
+			}
+			if got := rr.Body.String(); got != tt.want {
+				t.Errorf("Echo response body is wrong, got %q want %q", got, tt.want)
+			}
 		})
 	}
 }
@@ -114,37 +105,11 @@ func TestHealthCheckHandler(t *testing.T) {
 
 	// Check the status code is what we expect.
 	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusOK)
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
 	want := "text/plain; charset=utf-8"
 	if contentType := rr.Header().Get("Content-Type"); contentType != want {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			contentType, want)
-	}
-}
-
-func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
-	if a == b {
-		return
-	}
-	if message == "" {
-		message = fmt.Sprintf("%v != %v", a, b)
-	}
-	t.Fatal(message)
-}
-
-func assertStatus(t *testing.T, got, want int) {
-	t.Helper()
-	if got != want {
-		t.Errorf("did not get correct status, got %d, want %d", got, want)
-	}
-}
-
-func assertResponseBody(t *testing.T, got, want string) {
-	t.Helper()
-	if got != want {
-		t.Errorf("response body is wrong, got %q want %q", got, want)
+		t.Errorf("handler returned wrong status code: got %v want %v", contentType, want)
 	}
 }


### PR DESCRIPTION
There are a couple optional style changes in this that we might not want:
* I removed the `args` type for table test arguments and changed it to directly be the parts that change (`method` and `path`).
  * I like this because the parts that change between each test have as little indirection as possible.
    * When you're debugging the test, there is less indentation, etc., hopefully making it easier to debug.
    * Also, by doing `method` and `path` instead of a request, there is less copying and pasting for each test case. https://github.com/golang/go/wiki/TableDrivenTests#introduction mentioning "copy and paste" is relevant. Sometimes, requests are so different for each case that it makes sense to include the entire request type, but I don't think this is there yet.
* I removed the assert helpers in favor of checking and calling `t.Errorf` directly. I find this more readable, but others understandably disagree. https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures and https://github.com/golang/go/wiki/TestComments#assert-libraries are relevant.

I also removed the shared response recorder for each test and create a new one for each test case. If the test cases are ever made to run in parallel, there won't be any race conditions. Also, if the body is accidentally not reset, test cases will stay completely independent.

I switched the tests to use the `rr.Body.String()` helper rather than `actual, _ := ioutil.ReadAll(...); got := string(actual)`. This is a [helper of `httptest.ResponseRecorder`](https://golang.org/pkg/net/http/httptest/#ResponseRecorder).

I added `Echo` to the relevant test failures following https://github.com/golang/go/wiki/TestComments#identify-the-function. Also need this for the other tests, but I kept this PR mostly focused on `Echo`.