### PR TITLE
Listen on :PORT

### DIFF
--- a/01-startup/main.go
+++ b/01-startup/main.go
@@ -9,25 +9,29 @@ import (
 
 func main() {
 	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-	if err := runServer(logger); err != nil {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+	if err := runServer(logger, port); err != nil {
 		logger.Printf("Got error: %v", err)
 		os.Exit(1)
 	}
 	logger.Println("Finished clean")
 }
 
-func runServer(logger *log.Logger) error {
+func runServer(logger *log.Logger, port string) error {
 	// =========================================================================
 	// App Starting
 
-	logger.Printf("main : Started")
+	logger.Printf("main : Listening on :%v", port)
 	defer logger.Println("main : Completed")
 
 	// Convert the Echo function to a type that implements http.Handler
 	h := http.HandlerFunc(Echo)
 
 	// Start a server listening on port 8000 and responding using Echo.
-	if err := http.ListenAndServe("localhost:8000", h); err != nil {
+	if err := http.ListenAndServe(":"+port, h); err != nil {
 		logger.Printf("error: listening and serving: %s", err)
 		return err
 	}

--- a/02-shutdown/main.go
+++ b/02-shutdown/main.go
@@ -13,25 +13,29 @@ import (
 
 func main() {
 	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-	if err := runServer(logger); err != nil {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+	if err := runServer(logger, port); err != nil {
 		logger.Printf("Got error: %v", err)
 		os.Exit(1)
 	}
 	logger.Println("Finished clean")
 }
 
-func runServer(logger *log.Logger) error {
+func runServer(logger *log.Logger, port string) error {
 	// =========================================================================
 	// App Starting
 
-	logger.Printf("main : Started")
+	logger.Printf("main : Listening on :%v", port)
 	defer logger.Println("main : Completed")
 
 	// =========================================================================
 	// Start API Service
 
 	api := http.Server{
-		Addr:         "localhost:8000",
+		Addr:         ":" + port,
 		Handler:      http.HandlerFunc(Echo),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 5 * time.Second,

--- a/02-shutdown/main_test.go
+++ b/02-shutdown/main_test.go
@@ -65,7 +65,7 @@ func TestWaiter(t *testing.T) {
 		// Discard noisy logs
 		logger := log.New(ioutil.Discard, "", log.LstdFlags)
 		go func() {
-			runServer(logger)
+			runServer(logger, "8000")
 			finished = true
 		}()
 

--- a/02-shutdown/main_test.go
+++ b/02-shutdown/main_test.go
@@ -65,7 +65,7 @@ func TestWaiter(t *testing.T) {
 		// Discard noisy logs
 		logger := log.New(ioutil.Discard, "", log.LstdFlags)
 		go func() {
-			runServer(logger, "8000")
+			runServer(logger, "0")
 			finished = true
 		}()
 

--- a/03-json/main.go
+++ b/03-json/main.go
@@ -13,25 +13,29 @@ import (
 
 func main() {
 	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-	if err := runServer(logger); err != nil {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+	if err := runServer(logger, port); err != nil {
 		logger.Printf("Got error: %v", err)
 		os.Exit(1)
 	}
 	logger.Println("Finished clean")
 }
 
-func runServer(logger *log.Logger) error {
+func runServer(logger *log.Logger, port string) error {
 	// =========================================================================
 	// App Starting
 
-	logger.Printf("main : Started")
+	logger.Printf("main : Listening on :%v", port)
 	defer logger.Println("main : Completed")
 
 	// =========================================================================
 	// Start API Service
 
 	api := http.Server{
-		Addr:         "localhost:8000",
+		Addr:         ":" + port,
 		Handler:      http.HandlerFunc(ListTodos),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 5 * time.Second,

--- a/03-json/main_test.go
+++ b/03-json/main_test.go
@@ -60,7 +60,7 @@ func TestWaiter(t *testing.T) {
 		// Discard noisy logs
 		logger := log.New(ioutil.Discard, "", log.LstdFlags)
 		go func() {
-			runServer(logger)
+			runServer(logger, "8000")
 			finished = true
 		}()
 

--- a/03-json/main_test.go
+++ b/03-json/main_test.go
@@ -60,7 +60,7 @@ func TestWaiter(t *testing.T) {
 		// Discard noisy logs
 		logger := log.New(ioutil.Discard, "", log.LstdFlags)
 		go func() {
-			runServer(logger, "8000")
+			runServer(logger, "0")
 			finished = true
 		}()
 


### PR DESCRIPTION
ListenAndServe uses net.Listen (https://golang.org/pkg/net/#Listen),
which "if the host in the address parameter is empty or a literal
unspecified IP address, Listen listens on all available unicast and
anycast IP addresses of the local system."

There may be some systems where "localhost" is not correct.

I also switched to checking the PORT environment variable, which is
standard for where a container should listen for connections. So, while
not neccessary for running locally, it's a good practice to check for
the variable and fall back to a default if needed.

Finally, I updated the startuplogging message to include the address being listened
on.